### PR TITLE
5 add compatible for adc io channel

### DIFF
--- a/dts/bindings/sixtron-adc.yaml
+++ b/dts/bindings/sixtron-adc.yaml
@@ -5,7 +5,7 @@ description: |
     ADC channels exposed on sixtron connector.
 
     The sixtron connector layout provides a 4-pin Analog Input.
-    Thishas analog input signals labeled from ADC1 to ADC4.
+    This has analog input signals labeled from ADC1 to ADC4.
 
     This binding provides a nexus mapping for these pins.
 

--- a/dts/bindings/sixtron-adc.yaml
+++ b/dts/bindings/sixtron-adc.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 CATIE
+# Copyright (c) 2024 CATIE
 # SPDX-License-Identifier: Apache-2.0
 
 description: |

--- a/dts/bindings/sixtron-adc.yaml
+++ b/dts/bindings/sixtron-adc.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2023 CATIE
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    ADC channels exposed on sixtron connector.
+
+    The sixtron connector layout provides a 4-pin Analog Input.
+    Thishas analog input signals labeled from ADC1 to ADC4.
+
+    This binding provides a nexus mapping for these pins.
+
+compatible: "sixtron-adc"
+
+include: [base.yaml]
+
+properties:
+  io-channel-map:
+    type: compound
+    required: true
+
+  io-channel-map-mask:
+    type: compound
+
+  io-channel-map-pass-thru:
+    type: compound
+
+  "#io-channel-cells":
+    type: int
+    required: true
+    description: Number of items to expect in an ADC specifier


### PR DESCRIPTION
Added ADC mapping description for sixtron connector ADCs definition and mapping.
It is based on [GPIO nexus](https://github.com/devicetree-org/devicetree-specification/blob/4b1dac80eaca45b4babf5299452a951008a5d864/source/devicetree-basics.rst#nexus-nodes-and-specifier-mapping) and adapted to ADC specifier with `#io-channel-cells` property.