### PR TITLE
7 add compatible for pwm mapping

### DIFF
--- a/dts/bindings/sixtron-pwm.yaml
+++ b/dts/bindings/sixtron-pwm.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 CATIE
+# Copyright (c) 2024 CATIE
 # SPDX-License-Identifier: Apache-2.0
 
 description: |

--- a/dts/bindings/sixtron-pwm.yaml
+++ b/dts/bindings/sixtron-pwm.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2023 CATIE
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    PWM pins exposed on 6TRON connector.
+
+    The sixtron connector layout provides a 3-pin PWM Output.
+    This has output signals labeled from PWM1 to PWM3.
+
+compatible: "sixtron-pwm"
+
+include: [base.yaml]
+
+properties:
+  pwm-map:
+    type: compound
+    required: true
+
+  pwm-map-mask:
+    type: compound
+
+  pwm-map-pass-thru:
+    type: compound
+
+  "#pwm-cells":
+    type: int
+    required: true
+    description: Number of items to expect in a PWM specifier


### PR DESCRIPTION
Added PWM mapping description for sixtron connector PWMs definition and mapping.
It is based on [GPIO nexus](https://github.com/devicetree-org/devicetree-specification/blob/4b1dac80eaca45b4babf5299452a951008a5d864/source/devicetree-basics.rst#nexus-nodes-and-specifier-mapping) and adapted to PWM specifier with #pwm-cells property.